### PR TITLE
Release 1.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.0" %}
+{% set version = "1.1.0" %}
 
 package:
   name: bottleneck
@@ -7,10 +7,10 @@ package:
 source:
   fn: Bottleneck-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/B/Bottleneck/Bottleneck-{{ version }}.tar.gz
-  sha256: 8d9b7ad4fadf9648acc924a6ee522c7cb5b474e75faaad9d90dfd55e2805b495
+  sha256: c3a52b843509bd8d9ef240f0ce2f3e57d05277f85c3239196e3d8979fe5d33de
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
```rst
Bottleneck 1.1.0
----------------

*Release date: 2016-06-22*

This release makes Bottleneck more robust, releases GIL, adds new functions.

**More Robust**

- move_median can now handle NaNs and `min_count` parameter
- move_std is slower but numerically more stable
- Bottleneck no longer crashes on byte-swapped input arrays

**Faster**

- All Bottleneck functions release the GIL
- median is faster if the input array contains NaN
- move_median is faster for input arrays that contain lots of NaNs
- No speed penalty for median, nanmedian, nanargmin, nanargmax for Fortran
  ordered input arrays when axis is None
- Function call overhead cut in half for reduction along all axes (axis=None)
  if the input array satisfies at least one of the following properties: 1d,
  C contiguous, F contiguous
- Reduction along all axes (axis=None) is more than twice as fast for long,
  narrow input arrays such as a (1000000, 2) C contiguous array and a
  (2, 1000000) F contiguous array

**New Functions**

- move_var
- move_argmin
- move_argmax
- move_rank
- push

**Beware**

- median now returns NaN for a slice that contains one or more NaNs
- Instead of using the distutils default, the '-O2' C compiler flag is forced
- move_std output changed when mean is large compared to standard deviation
- Fixed: Non-accelerated moving window functions used min_count incorrectly
- move_median is a bit slower for float input arrays that do not contain NaN

**Thanks**

Alphabeticaly by last name

- Alessandro Amici worked on setup.py
- Pietro Battiston modernized bottleneck installation
- Moritz E. Beber set up continuous integration with Travis CI
- Jaime Frio improved the numerical stability of move_std
- Christoph Gohlke revived Windows compatibility
- Jennifer Olsen added NaN support to move_median
```