### PR TITLE
NP1.12 + Python 3.6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,17 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   matrix:
     
-    - CONDA_NPY=110  CONDA_PY=27
     - CONDA_NPY=111  CONDA_PY=27
-    - CONDA_NPY=110  CONDA_PY=34
-    - CONDA_NPY=111  CONDA_PY=34
-    - CONDA_NPY=110  CONDA_PY=35
+    - CONDA_NPY=112  CONDA_PY=27
     - CONDA_NPY=111  CONDA_PY=35
+    - CONDA_NPY=112  CONDA_PY=35
+    - CONDA_NPY=111  CONDA_PY=36
+    - CONDA_NPY=112  CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "66CgRGAHMh06NEBCLXenNGhy59lHdkXfWDABnWsMY6TZ78+QuVxLyrkJmDl1TlOzNoud6J/mheOFp38Vgh0KW/DexheokfMl4bk3PoGdl1AqV4WECykDRwSe+FyVT82BevG6L5FbOwQc6rAGrvF5ogfnThzrVIl8nHrsW9oxSmMImeeo3LJNdDLAeLZdIYZLieoEFK9vGnObZJXWULwnHHSIvMhFyg0v8DdwnGIGzku5rkXFBzlUbTS53OPZHRLiAZnzTbgNIMi++luRyJQde4OAiYCZ5krm12SYvT562il/mckdjfBVTXdGbxG/zAxaKzfhOHals0Iw/y8razQf1MNKYDQgTgChTEds0q227Wy+7QXGzs55ciZRtp5T3205NYbw5jF2QqGAIomc/FylcSCX+xqkP3h+Lnv5/TKKYsgwGCdmOg7Ol3FtLQVJ2Q/sGIIfFh+yGmivcvjVc6qHSv1hDJUp1NmMFJi2J90caTcnn2fGJu4HUv7AkU4lLtTEsnX4sUGm7dc4GOKRyzIFTAEg7FUrx2D6xakM3k1bKbgdOM3cG6f+OyFtJavBPOMOtnRGBeCyVljIbQym21dCraj0b2evCEiLE8SFmYLz1g3q/86/f4hTw/93Yb350MEMKqabRVlEu8yzbL7/Tc6m/Bgw1utOttgBojkX3KzY3og="
@@ -22,18 +22,32 @@ env:
 
 before_install:
     # Remove homebrew.
-    - brew remove --force $(brew list)
-    - brew cleanup -s
-    - rm -rf $(brew --cache)
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
 
 install:
+    # Install Miniconda.
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      echo ""
+      echo "Installing a fresh version of Miniconda."
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Bottleneck is a collection of fast NumPy array functions written in
 Cython.
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/bottleneck-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/bottleneck-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/bottleneck-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/bottleneck-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/bottleneck-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/bottleneck-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/bottleneck/badges/version.svg)](https://anaconda.org/conda-forge/bottleneck)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/bottleneck/badges/downloads.svg)](https://anaconda.org/conda-forge/bottleneck)
+
 Installing bottleneck
 =====================
 
@@ -33,7 +45,6 @@ It is possible to list all of the versions of `bottleneck` available on your pla
 ```
 conda search bottleneck --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -69,18 +80,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/bottleneck-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/bottleneck-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/bottleneck-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/bottleneck-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/bottleneck-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/bottleneck-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/bottleneck/badges/version.svg)](https://anaconda.org/conda-forge/bottleneck)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/bottleneck/badges/downloads.svg)](https://anaconda.org/conda-forge/bottleneck)
 
 
 Updating bottleneck-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,68 +4,45 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
 
   matrix:
     - TARGET_ARCH: x86
-      CONDA_NPY: 110
-      CONDA_PY: 27
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 110
-      CONDA_PY: 27
-
-    - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 27
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 110
-      CONDA_PY: 34
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 110
-      CONDA_PY: 34
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 111
-      CONDA_PY: 34
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 111
-      CONDA_PY: 34
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 110
-      CONDA_PY: 35
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 110
-      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -86,24 +63,21 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
 
-    # Add a hack to switch to `conda` version `4.1.12` before activating.
-    # This is required to handle a long path activation issue.
-    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda install --yes --quiet conda=4.1.12
-    - cmd: set "PATH=%OLDPATH%"
-    - cmd: set "OLDPATH="
-
+    # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda update --yes --quiet conda
+
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Add our channels.
     - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
+    - cmd: conda config --remove channels defaults
+    - cmd: conda config --add channels defaults
     - cmd: conda config --add channels conda-forge
+
+    # Configure the VM.
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -25,8 +25,8 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit $?
@@ -43,13 +43,6 @@ source run_conda_forge_build_setup
 
 # Embarking on 6 case(s).
     set -x
-    export CONDA_NPY=110
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
     export CONDA_NPY=111
     export CONDA_PY=27
     set +x
@@ -57,22 +50,8 @@ source run_conda_forge_build_setup
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=110
-    export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=111
-    export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=110
-    export CONDA_PY=35
+    export CONDA_NPY=112
+    export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
@@ -80,6 +59,27 @@ source run_conda_forge_build_setup
     set -x
     export CONDA_NPY=111
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=112
+    export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=111
+    export CONDA_PY=36
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=112
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1


### PR DESCRIPTION
Rerender with a recent conda smithy to build packages for numpy 1.12 and python 3.6.

Did not bump version, as the recipe did not change.