### PR TITLE
Update `home` URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About bottleneck
 ================
 
-Home: http://berkeleyanalytics.com/bottleneck
+Home: https://github.com/kwgoodman/bottleneck
 
 Package license: BSD 2-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
-  home: http://berkeleyanalytics.com/bottleneck
+  home: https://github.com/kwgoodman/bottleneck
   license: BSD 2-Clause
   license_family: BSD
   license_file: bottleneck/LICENSE


### PR DESCRIPTION
Fixes https://github.com/conda-forge/bottleneck-feedstock/issues/16

This home URL here was stale. It got changed in commit ( https://github.com/kwgoodman/bottleneck/commit/0f5227591fce85b2748e4d7a7810edbe406913ad ). This updates the URL used to match.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
