### PR TITLE
DOC: update homepage to reflect move to pydata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About bottleneck
 ================
 
-Home: https://github.com/kwgoodman/bottleneck
+Home: https://github.com/pydata/bottleneck
 
 Package license: BSD 2-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
-  home: https://github.com/kwgoodman/bottleneck
+  home: https://github.com/pydata/bottleneck
   license: BSD 2-Clause
   license_family: BSD
   license_file: bottleneck/LICENSE
@@ -48,8 +48,8 @@ about:
   description: |
     Bottleneck is a collection of fast NumPy array functions written in
     Cython.
-  doc_url: http://berkeleyanalytics.com/bottleneck
-  dev_url: https://github.com/kwgoodman/bottleneck
+  doc_url: http://bottleneck.readthedocs.io
+  dev_url: https://github.com/pydata/bottleneck
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Hi,

I'm the new maintainer of `bottleneck` and the homepage has been moved to `pydata/bottleneck`. I will be releasing `1.3.0` soon and will send a separate PR for that.

Thanks,
Chris
